### PR TITLE
Set up Laravel Pint + docs (AGENTS.md, README)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -39,15 +39,11 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Get composer cache directory
-        id: composer-cache-dir
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v4
         with:
-            path: ${{ steps.composer-cache-dir.outputs.dir }}
+            path: vendor
             key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
             restore-keys: |
               ${{ runner.os }}-php-

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -56,6 +56,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress --no-suggest
 
+      - name: Check code style
+        run: vendor/bin/pint --test
+
         # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
         # Docs: https://getcomposer.org/doc/articles/scripts.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## What this project is
+
+`puntodev/mercadopago` is a **Laravel package** (Composer library) that provides a
+lightweight client for the **MercadoPago API**: Checkout preferences, merchant orders
+and payment search. It is not an application: it is published to Packagist and
+consumed from Laravel apps.
+
+- **Namespace:** `Puntodev\MercadoPago\` (PSR-4, mapped to `src/`)
+- **PHP:** `>=8.4 <9.0`
+- **Main dependency:** `illuminate/support` (`^12.53 || ^13.0`)
+- **License:** MIT
+
+## Architecture
+
+The package is built around two interfaces and their implementations, plus a pair of
+builders that assemble the Checkout preference payload.
+
+| File | Role |
+|------|------|
+| `src/MercadoPago.php` | Factory interface. Exposes `defaultClient()`, `withCredentials($id, $secret)` and `usingSandbox()`. |
+| `src/MercadoPagoClient.php` | `MercadoPago` implementation. A `readonly` class that holds the `useSandbox` flag and creates `MercadoPagoApiClient` instances from the configured credentials. |
+| `src/MercadoPagoApi.php` | HTTP client interface: `createPaymentPreference`, `findMerchantOrders`, `findMerchantOrderById`, `findPayments`, `findPaymentById`. |
+| `src/MercadoPagoApiClient.php` | Real implementation against the MercadoPago API (`api.mercadopago.com`) using Laravel's HTTP client (`Http`). Handles the cached OAuth2 token. |
+| `src/PaymentPreferenceBuilder.php` | Fluent builder that assembles the Checkout preference array (`items`, `payer`, `back_urls`, `payment_methods`, expiration, `binary_mode`, etc.). |
+| `src/PaymentPreferenceItemBuilder.php` | Nested builder for a single preference item (`title`, `quantity`, `unit_price`, `currency`); `make()` returns to the parent `PaymentPreferenceBuilder`. |
+| `src/MercadoPagoServiceProvider.php` | Registers `MercadoPago` as a singleton, publishes the config and applies `mergeConfigFrom`. |
+| `src/Facades/MercadoPago.php` | `MercadoPago` facade resolving to the `MercadoPago::class` binding. |
+| `config/mercadopago.php` | Reads `MERCADOPAGO_API_CLIENT_ID`, `MERCADOPAGO_API_CLIENT_SECRET`, `SANDBOX_GATEWAYS`. |
+
+### Important behavior details
+
+- **Sandbox vs production:** the `useSandbox` flag is read from the `SANDBOX_GATEWAYS`
+  env var and exposed via `usingSandbox()`. Unlike host-switching gateways, the API
+  host is always `api.mercadopago.com`: MercadoPago distinguishes sandbox via test
+  credentials/test users, and `createPaymentPreference` responses include both an
+  `init_point` (production) and a `sandbox_init_point` (sandbox) checkout URL.
+- **OAuth2 token:** `getToken()` caches the `access_token` for 1000 seconds under the
+  key `mercadopago-token-{clientId}` via `Cache::remember`. It uses `withBasicAuth`
+  against `/oauth/token` with `grant_type=client_credentials`.
+- **Requests:** all calls use `->throw()`, so HTTP errors propagate as
+  `RequestException`. Search endpoints (`findMerchantOrders`, `findPayments`) accept an
+  optional query array passed through `withQueryParameters`.
+- **PaymentPreferenceBuilder:** `auto_return` is fixed to `all`; the `pending`/`failure`
+  back URLs fall back to the success URL; the expiration block is only populated when an
+  expiration is set (formatted with `MP_DATE_TIME_FORMAT`); `excluded_payment_types` is
+  only sent when excluded methods are provided. Item `unit_price` is rounded to two
+  decimals and the default item currency is `ARS`.
+
+## Laravel auto-registration (package discovery)
+
+Defined in `composer.json` → `extra.laravel`:
+- Provider: `Puntodev\MercadoPago\MercadoPagoServiceProvider`
+- Alias/Facade: `MercadoPago` → `Puntodev\MercadoPago\Facades\MercadoPago`
+
+## How to run and test
+
+```bash
+composer install
+composer test            # vendor/bin/phpunit
+composer test-coverage   # generates HTML coverage report under ./coverage
+composer lint            # vendor/bin/pint --test (style check, no changes)
+composer format          # vendor/bin/pint (fix style)
+```
+
+- Tests use **Orchestra Testbench** (`tests/TestCase.php` extends
+  `Orchestra\Testbench\TestCase` and registers the service provider).
+- `phpunit.xml.dist` forces `SANDBOX_GATEWAYS=true`.
+- ⚠️ **`tests/MercadoPagoApiTest.php` makes real HTTP calls to MercadoPago.** It requires
+  valid credentials in `MERCADOPAGO_API_CLIENT_ID` / `MERCADOPAGO_API_CLIENT_SECRET`
+  (in `.env` locally, or GitHub Secrets in CI). These are not isolated unit tests.
+- CI: `.github/workflows/php.yml` runs on PHP 8.4 on every push/PR to `master`,
+  including a Pint code-style check.
+
+## Conventions
+
+- Code style is enforced by **Laravel Pint** (`pint.json`, `laravel` preset). Run
+  `composer format` before committing; `composer lint` is what CI runs.
+- The interfaces (`MercadoPago`, `MercadoPagoApi`) are the public contract: when adding a
+  method to the client, add it to the interface and to the tests as well.
+- API methods return `array`/`?array` (Laravel's `->json()`); keep that convention.
+
+## Workflow rules (inherited from the user's global config)
+
+- **Do not commit on `master`.** Always work on a branch or worktree.
+- PRs are always opened as **Draft**.
+- Run `git pull` before starting to make sure you have the latest version.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,156 @@
-# Very short description of the package
+# MercadoPago API Client for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/puntodev/mercadopago.svg?style=flat-square)](https://packagist.org/packages/puntodev/mercadopago)
-[![Build Status](https://img.shields.io/travis/puntodev/mercadopago/master.svg?style=flat-square)](https://travis-ci.org/puntodev/mercadopago)
-[![Quality Score](https://img.shields.io/scrutinizer/g/puntodev/mercadopago.svg?style=flat-square)](https://scrutinizer-ci.com/g/puntodev/mercadopago)
 [![Total Downloads](https://img.shields.io/packagist/dt/puntodev/mercadopago.svg?style=flat-square)](https://packagist.org/packages/puntodev/mercadopago)
 
-This is where your description should go. Try and limit it to a paragraph or two, and maybe throw in a mention of what PSRs you support to avoid any confusion with users and contributors.
+A lightweight Laravel package that wraps the [MercadoPago API](https://www.mercadopago.com.ar/developers)
+to create Checkout preferences and look up merchant orders and payments. It uses
+Laravel's HTTP client under the hood and caches the OAuth2 access token automatically.
+
+## Requirements
+
+- PHP `>=8.4 <9.0`
+- Laravel 12 / 13 (`illuminate/support` `^12.53 || ^13.0`)
 
 ## Installation
 
-You can install the package via composer:
+Install via composer:
 
 ```bash
 composer require puntodev/mercadopago
 ```
 
+The package auto-registers its service provider and the `MercadoPago` facade via Laravel
+package discovery. To publish the config file:
+
+```bash
+php artisan vendor:publish --provider="Puntodev\MercadoPago\MercadoPagoServiceProvider" --tag="config"
+```
+
+## Configuration
+
+Set the following environment variables:
+
+```dotenv
+MERCADOPAGO_API_CLIENT_ID=your-client-id
+MERCADOPAGO_API_CLIENT_SECRET=your-client-secret
+SANDBOX_GATEWAYS=true   # exposed via usingSandbox()
+```
+
+These map to `config/mercadopago.php`:
+
+```php
+return [
+    'client_id' => env('MERCADOPAGO_API_CLIENT_ID'),
+    'client_secret' => env('MERCADOPAGO_API_CLIENT_SECRET'),
+    'use_sandbox' => env('SANDBOX_GATEWAYS', false),
+];
+```
+
+The API host is always `api.mercadopago.com`. MercadoPago distinguishes sandbox from
+production through your credentials/test users: when creating a preference the response
+includes both an `init_point` (production) and a `sandbox_init_point` (sandbox) checkout
+URL. The `use_sandbox` flag is surfaced through `usingSandbox()` so your application can
+decide which checkout URL to use.
+
 ## Usage
 
-``` php
-// Usage description here
+### Resolving the client
+
+Inject the `MercadoPago` contract (or use the `MercadoPago` facade) and obtain a
+`MercadoPagoApi` instance. Use `defaultClient()` to use the configured credentials, or
+`withCredentials()` to override them at runtime (e.g. for multi-tenant setups):
+
+```php
+use Puntodev\MercadoPago\MercadoPago;
+
+public function __construct(private MercadoPago $mercadoPago) {}
+
+// With the credentials from config/mercadopago.php
+$api = $this->mercadoPago->defaultClient();
+
+// Or with per-request credentials
+$api = $this->mercadoPago->withCredentials($clientId, $clientSecret);
 ```
 
-### Testing
+### Building a payment preference
 
-``` bash
-composer test
+`PaymentPreferenceBuilder` produces the payload for the Checkout Preferences API. Items
+are added through the nested `PaymentPreferenceItemBuilder` returned by `item()`. The
+`pending` / `failure` back URLs default to the success URL, `auto_return` is `all`, and an
+expiration window is only sent when provided:
+
+```php
+use Puntodev\MercadoPago\PaymentPreferenceBuilder;
+
+$preference = (new PaymentPreferenceBuilder())
+    ->item()
+        ->title('My custom product')
+        ->unitPrice(23.20)
+        ->quantity(1)
+        ->currency('ARS')      // defaults to ARS
+        ->make()
+    ->externalId('your-internal-id')
+    ->payerFirstName('John')
+    ->payerLastName('Doe')
+    ->payerEmail('john@example.com')
+    ->notificationUrl('https://example.com/mp/ipn')
+    ->successBackUrl('https://example.com/return')
+    ->binaryMode(true)
+    ->make();
 ```
 
-### Changelog
+### Creating a preference and looking up orders/payments
 
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+```php
+$created = $api->createPaymentPreference($preference);
+
+// Send the buyer to the appropriate checkout URL
+$checkoutUrl = $api->usingSandbox()
+    ? $created['sandbox_init_point']
+    : $created['init_point'];
+
+// Later, look up merchant orders and payments
+$orders = $api->findMerchantOrders(['external_reference' => 'your-internal-id']);
+$order = $api->findMerchantOrderById($orderId);
+
+$payments = $api->findPayments(['external_reference' => 'your-internal-id']);
+$payment = $api->findPaymentById($paymentId);
+```
+
+All methods return the decoded JSON response as an `array` (or `null`) and throw
+`Illuminate\Http\Client\RequestException` on HTTP errors.
+
+## Testing
+
+```bash
+composer test            # runs PHPUnit
+composer test-coverage   # generates HTML coverage report
+```
+
+> **Note:** the test suite (`tests/MercadoPagoApiTest.php`) makes **real HTTP calls to
+> the MercadoPago API**. You must provide valid credentials via
+> `MERCADOPAGO_API_CLIENT_ID` and `MERCADOPAGO_API_CLIENT_SECRET`. `phpunit.xml.dist`
+> forces `SANDBOX_GATEWAYS=true`.
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-### Security
+## Security
 
-If you discover any security related issues, please email mariano.goldman@puntodev.com.ar instead of using the issue tracker.
+If you discover any security related issues, please email mariano.goldman@puntodev.com.ar
+instead of using the issue tracker.
 
 ## Credits
 
-- [Mariano Goldman](https://github.com/marianogoldman)
+- [Mariano Goldman](https://github.com/puntodev)
 - [All Contributors](../../contributors)
 
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-
-## Laravel Package Boilerplate
-
-This package was generated using the [Laravel Package Boilerplate](https://laravelpackageboilerplate.com).

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "illuminate/support": "^12.53 || ^13.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.29",
         "orchestra/testbench": "^10.11",
         "phpunit/phpunit": "^12.5"
     },
@@ -35,7 +36,9 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "lint": "vendor/bin/pint --test",
+        "format": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ff93fcb296fd9402b8ec90e27b76a0d",
+    "content-hash": "1d7e4174661aeb52b7c22f1fd8151ea5",
     "packages": [
         {
             "name": "brick/math",
@@ -6140,6 +6140,74 @@
                 "source": "https://github.com/laravel/pail"
             },
             "time": "2026-02-09T13:44:54+00:00"
+        },
+        {
+            "name": "laravel/pint",
+            "version": "v1.29.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pint.git",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-tokenizer": "*",
+                "ext-xml": "*",
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "illuminate/view": "^12.56.0",
+                "larastan/larastan": "^3.9.6",
+                "laravel-zero/framework": "^12.1.0",
+                "mockery/mockery": "^1.6.12",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.3"
+            },
+            "bin": [
+                "builds/pint"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "App\\": "app/",
+                    "Database\\Seeders\\": "database/seeders/",
+                    "Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "An opinionated code formatter for PHP.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "dev",
+                "format",
+                "formatter",
+                "lint",
+                "linter",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pint/issues",
+                "source": "https://github.com/laravel/pint"
+            },
+            "time": "2026-04-20T15:26:14+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,13 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": false,
+        "ordered_imports": {
+            "sort_algorithm": "alpha"
+        },
+        "no_unused_imports": true,
+        "concat_space": {
+            "spacing": "one"
+        }
+    }
+}

--- a/src/Facades/MercadoPago.php
+++ b/src/Facades/MercadoPago.php
@@ -4,7 +4,6 @@ namespace Puntodev\MercadoPago\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-
 /**
  * @method static \Puntodev\MercadoPago\MercadoPagoApi defaultClient()
  * @method static \Puntodev\MercadoPago\MercadoPagoApi withCredentials(string $clientId, string $clientSecret)

--- a/src/MercadoPagoApi.php
+++ b/src/MercadoPagoApi.php
@@ -7,36 +7,26 @@ use Illuminate\Http\Client\RequestException;
 interface MercadoPagoApi
 {
     /**
-     * @param array $order
-     * @return array
      * @throws RequestException
      */
     public function createPaymentPreference(array $order): array;
 
     /**
-     * @param array $query
-     * @return array|null
      * @throws RequestException
      */
     public function findMerchantOrders(array $query = []): ?array;
 
     /**
-     * @param string $id
-     * @return array|null
      * @throws RequestException
      */
     public function findMerchantOrderById(string $id): ?array;
 
     /**
-     * @param array $query
-     * @return array|null
      * @throws RequestException
      */
     public function findPayments(array $query = []): ?array;
 
     /**
-     * @param string $id
-     * @return array|null
      * @throws RequestException
      */
     public function findPaymentById(string $id): ?array;

--- a/src/MercadoPagoApiClient.php
+++ b/src/MercadoPagoApiClient.php
@@ -10,7 +10,9 @@ use Illuminate\Support\Facades\Log;
 class MercadoPagoApiClient implements MercadoPagoApi
 {
     private string $apiClientKey;
+
     private string $apiClientSecret;
+
     private string $host;
 
     public function __construct(string $apiClientKey, string $apiClientSecret)
@@ -26,6 +28,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     public function createPaymentPreference(array $order): array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->post("https://{$this->host}/checkout/preferences", $order)
             ->throw()
@@ -38,6 +41,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     public function findMerchantOrders(array $query = []): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->withQueryParameters($query)
             ->get("https://{$this->host}/merchant_orders")
@@ -51,6 +55,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     public function findMerchantOrderById(string $id): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->get("https://{$this->host}/merchant_orders/$id")
             ->throw()
@@ -63,6 +68,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     public function findPayments(array $query = []): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->withQueryParameters($query)
             ->get("https://{$this->host}/v1/payments/search")
@@ -76,6 +82,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     public function findPaymentById(string $id): ?array
     {
         $token = $this->getToken();
+
         return Http::withToken($token['access_token'])
             ->get("https://{$this->host}/v1/payments/$id")
             ->throw()
@@ -86,6 +93,7 @@ class MercadoPagoApiClient implements MercadoPagoApi
     {
         return Cache::remember("mercadopago-token-{$this->apiClientKey}", 1000, function () {
             Log::debug('Obtaining MercadoPago token from live server');
+
             return Http::withBasicAuth($this->apiClientKey, $this->apiClientSecret)
                 ->asJson()
                 ->post("https://{$this->host}/oauth/token", [

--- a/src/MercadoPagoClient.php
+++ b/src/MercadoPagoClient.php
@@ -4,9 +4,7 @@ namespace Puntodev\MercadoPago;
 
 readonly class MercadoPagoClient implements MercadoPago
 {
-    public function __construct(private bool $useSandbox = false)
-    {
-    }
+    public function __construct(private bool $useSandbox = false) {}
 
     public function defaultClient(): MercadoPagoApi
     {

--- a/src/PaymentPreferenceBuilder.php
+++ b/src/PaymentPreferenceBuilder.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Puntodev\MercadoPago;
-
 
 use Carbon\Carbon;
 use DateTime;
@@ -14,139 +12,111 @@ class PaymentPreferenceBuilder
     private array $items = [];
 
     private string $externalId = '';
+
     private string $payerFirstName = '';
+
     private string $payerLastName = '';
+
     private string $payerEmail = '';
+
     private string $successBackUrl = '';
+
     private string $pendingBackUrl = '';
+
     private string $failureBackUrl = '';
+
     private string $notificationUrl = '';
-    private DateTime|null $expiration = null;
+
+    private ?DateTime $expiration = null;
+
     private bool $binaryMode = false;
+
     private array $excludedPaymentMethods = [];
 
     /**
      * PaymentPreferenceBuilder constructor.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
-    /**
-     * @param string $externalId
-     * @return static
-     */
     public function externalId(string $externalId): static
     {
         $this->externalId = $externalId;
+
         return $this;
     }
 
-    /**
-     * @return PaymentPreferenceItemBuilder
-     */
     public function item(): PaymentPreferenceItemBuilder
     {
         return new PaymentPreferenceItemBuilder($this);
     }
 
-    /**
-     * @param string $payerFirstName
-     * @return static
-     */
     public function payerFirstName(string $payerFirstName): static
     {
         $this->payerFirstName = $payerFirstName;
+
         return $this;
     }
 
-    /**
-     * @param string $payerLastName
-     * @return static
-     */
     public function payerLastName(string $payerLastName): static
     {
         $this->payerLastName = $payerLastName;
+
         return $this;
     }
 
-    /**
-     * @param string $payerEmail
-     * @return static
-     */
     public function payerEmail(string $payerEmail): static
     {
         $this->payerEmail = $payerEmail;
+
         return $this;
     }
 
-    /**
-     * @param array $excludedPaymentMethods
-     * @return static
-     */
     public function excludedPaymentMethods(array $excludedPaymentMethods): static
     {
         $this->excludedPaymentMethods = $excludedPaymentMethods;
+
         return $this;
     }
 
-    /**
-     * @param string $successBackUrl
-     * @return static
-     */
     public function successBackUrl(string $successBackUrl): static
     {
         $this->successBackUrl = $successBackUrl;
+
         return $this;
     }
 
-    /**
-     * @param string $pendingBackUrl
-     * @return static
-     */
     public function pendingBackUrl(string $pendingBackUrl): static
     {
         $this->pendingBackUrl = $pendingBackUrl;
+
         return $this;
     }
 
-    /**
-     * @param string $failureBackUrl
-     * @return static
-     */
     public function failureBackUrl(string $failureBackUrl): static
     {
         $this->failureBackUrl = $failureBackUrl;
+
         return $this;
     }
 
-    /**
-     * @param string $notificationUrl
-     * @return static
-     */
     public function notificationUrl(string $notificationUrl): static
     {
         $this->notificationUrl = $notificationUrl;
+
         return $this;
     }
 
-    /**
-     * @param DateTime|null $expiration
-     * @return static
-     */
-    public function expiration(DateTime|null $expiration): static
+    public function expiration(?DateTime $expiration): static
     {
         $this->expiration = $expiration;
+
         return $this;
     }
 
-    /**
-     * @param bool $binaryMode
-     * @return static
-     */
     public function binaryMode(bool $binaryMode): static
     {
         $this->binaryMode = $binaryMode;
+
         return $this;
     }
 
@@ -161,7 +131,7 @@ class PaymentPreferenceBuilder
     {
         $paymentMethods = count($this->excludedPaymentMethods) > 0 ? [
             'excluded_payment_types' => collect($this->excludedPaymentMethods)
-                ->map(fn($pm) => ['id' => $pm])
+                ->map(fn ($pm) => ['id' => $pm])
                 ->toArray(),
         ] : [];
 

--- a/src/PaymentPreferenceItemBuilder.php
+++ b/src/PaymentPreferenceItemBuilder.php
@@ -1,60 +1,47 @@
 <?php
 
-
 namespace Puntodev\MercadoPago;
-
 
 class PaymentPreferenceItemBuilder
 {
     private string $title = '';
+
     private int $quantity = 1;
+
     private float $unitPrice = 0.0;
+
     private string $currency = 'ARS';
 
     /**
      * PaymentPreferenceItemBuilder constructor.
      */
-    public function __construct(private readonly PaymentPreferenceBuilder $paymentPreferenceBuilder)
-    {
-    }
+    public function __construct(private readonly PaymentPreferenceBuilder $paymentPreferenceBuilder) {}
 
-    /**
-     * @param string $title
-     * @return static
-     */
     public function title(string $title): static
     {
         $this->title = $title;
+
         return $this;
     }
 
-    /**
-     * @param int $quantity
-     * @return static
-     */
     public function quantity(int $quantity): static
     {
         $this->quantity = $quantity;
+
         return $this;
     }
 
-    /**
-     * @param float $unitPrice
-     * @return static
-     */
     public function unitPrice(float $unitPrice): static
     {
         $this->unitPrice = $unitPrice;
+
         return $this;
     }
 
-    /**
-     * @param string $currency
-     * @return static
-     */
     public function currency(string $currency): static
     {
         $this->currency = $currency;
+
         return $this;
     }
 

--- a/tests/MercadoPagoApiTest.php
+++ b/tests/MercadoPagoApiTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Exception;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Client\RequestException;
+use PHPUnit\Framework\Attributes\Test;
 use Puntodev\MercadoPago\MercadoPagoApi;
 use Puntodev\MercadoPago\MercadoPagoApiClient;
 use Puntodev\MercadoPago\PaymentPreferenceBuilder;
@@ -25,11 +26,10 @@ class MercadoPagoApiTest extends TestCase
     }
 
     /**
-     * @return void
-     *
      * @throws RequestException
      */
-    public function test_create_order()
+    #[Test]
+    public function create_order()
     {
         $order = (new PaymentPreferenceBuilder)
             ->item()
@@ -67,66 +67,60 @@ class MercadoPagoApiTest extends TestCase
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_merchant_orders()
+    #[Test]
+    public function find_merchant_orders()
     {
         $merchantOrders = $this->mercadoPagoApi->findMerchantOrders();
         $this->assertIsArray($merchantOrders);
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_merchant_order_by_id()
+    #[Test]
+    public function find_merchant_order_by_id()
     {
         $payment = $this->mercadoPagoApi->findMerchantOrderById('1129339369');
         $this->assertIsArray($payment);
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_order_by_id_invalid()
+    #[Test]
+    public function find_order_by_id_invalid()
     {
         $this->expectException(RequestException::class);
         $this->mercadoPagoApi->findMerchantOrderById('invalid-id');
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_payments()
+    #[Test]
+    public function find_payments()
     {
         $payment = $this->mercadoPagoApi->findPayments();
         $this->assertIsArray($payment);
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_payments_by_id()
+    #[Test]
+    public function find_payments_by_id()
     {
         $payment = $this->mercadoPagoApi->findPaymentById('5287653537');
         $this->assertIsArray($payment);
     }
 
     /**
-     * @return void
-     *
      * @throws Exception
      */
-    public function test_find_payments_by_id_invalid()
+    #[Test]
+    public function find_payments_by_id_invalid()
     {
         $this->expectException(RequestException::class);
         $this->mercadoPagoApi->findPaymentById('invalid-id');

--- a/tests/MercadoPagoApiTest.php
+++ b/tests/MercadoPagoApiTest.php
@@ -15,7 +15,7 @@ class MercadoPagoApiTest extends TestCase
 
     private MercadoPagoApi $mercadoPagoApi;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mercadoPagoApi = new MercadoPagoApiClient(
@@ -26,11 +26,12 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws RequestException
      */
-    public function testCreateOrder()
+    public function test_create_order()
     {
-        $order = (new PaymentPreferenceBuilder())
+        $order = (new PaymentPreferenceBuilder)
             ->item()
             ->title('My custom product')
             ->unitPrice(23.20)
@@ -67,9 +68,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindMerchantOrders()
+    public function test_find_merchant_orders()
     {
         $merchantOrders = $this->mercadoPagoApi->findMerchantOrders();
         $this->assertIsArray($merchantOrders);
@@ -77,9 +79,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindMerchantOrderById()
+    public function test_find_merchant_order_by_id()
     {
         $payment = $this->mercadoPagoApi->findMerchantOrderById('1129339369');
         $this->assertIsArray($payment);
@@ -87,9 +90,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindOrderByIdInvalid()
+    public function test_find_order_by_id_invalid()
     {
         $this->expectException(RequestException::class);
         $this->mercadoPagoApi->findMerchantOrderById('invalid-id');
@@ -97,9 +101,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindPayments()
+    public function test_find_payments()
     {
         $payment = $this->mercadoPagoApi->findPayments();
         $this->assertIsArray($payment);
@@ -107,9 +112,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindPaymentsById()
+    public function test_find_payments_by_id()
     {
         $payment = $this->mercadoPagoApi->findPaymentById('5287653537');
         $this->assertIsArray($payment);
@@ -117,9 +123,10 @@ class MercadoPagoApiTest extends TestCase
 
     /**
      * @return void
+     *
      * @throws Exception
      */
-    public function testFindPaymentsByIdInvalid()
+    public function test_find_payments_by_id_invalid()
     {
         $this->expectException(RequestException::class);
         $this->mercadoPagoApi->findPaymentById('invalid-id');

--- a/tests/MercadoPagoTest.php
+++ b/tests/MercadoPagoTest.php
@@ -4,7 +4,6 @@ namespace Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use Puntodev\MercadoPago\MercadoPago;
-use Puntodev\MercadoPago\MercadoPagoApi;
 use Puntodev\MercadoPago\MercadoPagoApiClient;
 
 class MercadoPagoTest extends TestCase

--- a/tests/PaymentPreferenceBuilderTest.php
+++ b/tests/PaymentPreferenceBuilderTest.php
@@ -4,16 +4,15 @@ namespace Tests;
 
 use Carbon\Carbon;
 use PHPUnit\Framework\Attributes\Test;
-use Puntodev\MercadoPago\PaymentPreferenceBuilder;
 use PHPUnit\Framework\TestCase;
+use Puntodev\MercadoPago\PaymentPreferenceBuilder;
 
 class PaymentPreferenceBuilderTest extends TestCase
 {
-
     #[Test]
     public function create_order_with_int_amount()
     {
-        $order = (new PaymentPreferenceBuilder())
+        $order = (new PaymentPreferenceBuilder)
             ->externalId('31fe5538-8589-437d-8823-3b0574186a5f')
             ->item()
             ->title('My custom product')
@@ -29,7 +28,7 @@ class PaymentPreferenceBuilderTest extends TestCase
             ->pendingBackUrl('https://localhost:8080/pending')
             ->failureBackUrl('https://localhost:8080/failure')
             ->notificationUrl('https://localhost:8080/notification')
-            ->expiration(Carbon::parse("2021-05-21T20:45:32"))
+            ->expiration(Carbon::parse('2021-05-21T20:45:32'))
             ->binaryMode(true)
             ->make();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            MercadoPagoServiceProvider::class
+            MercadoPagoServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
## Summary

Mirrors the PayPal client setup (puntodev/paypal#47).

- **Docs:** add `AGENTS.md` describing the package architecture, behavior and workflow for AI agents; replace the boilerplate `README.md` with real installation, configuration and usage documentation.
- **Laravel Pint:** add `laravel/pint` as a dev dependency with a `laravel`-preset `pint.json`, `composer lint`/`composer format` scripts, and a code-style check step in CI (`.github/workflows/php.yml`).
- Apply Pint formatting to the existing `src/` and `tests/` (cosmetic only).

Dependency requirements are unchanged here (`illuminate/support` `^12.53 || ^13.0`); the Laravel 13+ bump follows in a separate PR.

## Test plan

- `composer lint` passes (`vendor/bin/pint --test`).
- `composer validate` passes.
- The `MercadoPagoApiTest` suite hits the real sandbox API and runs in CI with secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)