### PR TITLE
Automate the release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Configures GitHub's "Generate release notes" button.
+# Pull requests are grouped by their labels; the catch-all category ensures
+# every merged PR shows up even when it is unlabeled.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: 🛡️ Security
+      labels:
+        - security
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧰 Maintenance & Dependencies
+      labels:
+        - chore
+        - dependencies
+        - maintenance
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,38 @@
+name: Update Changelog
+
+# When a (non-prerelease) GitHub Release is published, write its notes into
+# CHANGELOG.md under the released version and commit the result back to master.
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          # Admin PAT so the changelog commit can be pushed to the protected
+          # master branch (the default GITHUB_TOKEN is rejected by branch
+          # protection). Requires enforce_admins to be disabled on master.
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
+
+      - name: Update CHANGELOG
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: master
+          commit_message: "docs: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          file_pattern: CHANGELOG.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ consumed from Laravel apps.
 
 - **Namespace:** `Puntodev\MercadoPago\` (PSR-4, mapped to `src/`)
 - **PHP:** `>=8.4 <9.0`
-- **Main dependency:** `illuminate/support` (`^12.53 || ^13.0`)
+- **Main dependency:** `illuminate/support` (`^13.0`, Laravel 13+)
 - **License:** MIT
 
 ## Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,118 @@
 # Changelog
 
-All notable changes to `MercadoPago` will be documented in this file
+All notable changes to `mercadopago` are documented in this file.
 
-## 1.0.0 - 201X-XX-XX
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- initial release
+Released entries below are maintained automatically from the GitHub release notes
+(see `.github/workflows/update-changelog.yml`); the `Unreleased` section tracks the
+range of changes on `master` that have not been released yet.
+
+## [Unreleased]
+
+## v6.0.0 - 2026-03-28
+
+- Refactor to use an interface and simplify the `MercadoPagoApi` implementation (#42).
+
+## v5.1.2 - 2026-03-07
+
+- Update dependencies (#39).
+
+## v5.1.1 - 2025-11-22
+
+- Update dependencies (#35).
+
+## v5.1.0 - 2025-11-09
+
+- Support for PHP 8.3 and newer (#34).
+
+## v5.0.1 - 2025-05-20
+
+- Update dependencies (#33).
+
+## v5.0.0 - 2025-05-02
+
+- Support Laravel 12 (#31).
+
+## v4.0.5 - 2025-03-19
+
+- Update libraries (#30).
+
+## v4.0.4 - 2025-02-01
+
+- Update libraries (#28).
+
+## v4.0.3 - 2024-12-10
+
+- Bump `league/commonmark` from 2.5.3 to 2.6.0 (#26).
+
+## v4.0.2 - 2024-11-30
+
+- Improve test coverage (#25).
+
+## v4.0.1 - 2024-11-12
+
+- Update libraries (#22).
+
+## v4.0.0 - 2024-04-07
+
+- Support Laravel 11 (#19).
+
+## v3.0.1 - 2023-04-26
+
+- Bump `guzzlehttp/psr7` from 2.4.4 to 2.5.0 (#18).
+
+## v3.0.0 - 2023-03-18
+
+- Support Laravel 10 (#17).
+
+## v2.1.2 - 2022-06-21
+
+- Bump `guzzlehttp/guzzle` from 7.4.4 to 7.4.5 (#16).
+
+## v2.1.1 - 2022-06-10
+
+- Security: bump `guzzlehttp/guzzle` from 7.4.2 to 7.4.4.
+
+## v2.1.0 - 2022-04-11
+
+- Support for Laravel 9 (#15).
+
+## v2.0.1 - 2022-03-30
+
+- Bump `guzzlehttp/psr7` from 1.8.2 to 1.8.5 (#14).
+
+## v2.0.0 - 2021-05-22
+
+- Rename namespace, improve the facade and expose whether the sandbox is in use (#9–#12).
+
+## v1.1.1 - 2021-04-30
+
+- Bump `laravel/framework` from 8.26.1 to 8.40.0 (#8).
+
+## v1.1.0 - 2021-01-23
+
+- Support for decimal numbers in the amount (#6).
+
+## v1.0.1 - 2021-01-19
+
+- Bump `laravel/framework` from 8.16.1 to 8.23.1 (#5).
+
+## 1.0.0 - 2020-11-26
+
+- Support for PHP 8 (#4).
+
+## v0.0.3 - 2020-10-11
+
+- Rename `OrderBuilder` to `PaymentPreferenceBuilder` (#3).
+
+## v0.0.2 - 2020-10-11
+
+- Fix package name casing in links to Packagist (#2).
+
+## v0.0.1 - 2020-10-11
+
+- Initial code migration from client project (#1).
+
+[Unreleased]: https://github.com/puntodev/mercadopago/compare/v6.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ composer test-coverage   # generates HTML coverage report
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
 
+## Releasing
+
+Releases are cut from GitHub and the changelog is kept in sync automatically:
+
+1. Merge the pull requests you want to ship into `master`. Label them so the notes
+   group nicely (`security`, `enhancement`, `bug`, `dependencies`, `documentation`);
+   grouping is configured in [`.github/release.yml`](.github/release.yml).
+2. On GitHub, go to **Releases → Draft a new release**, create a `vX.Y.Z` tag
+   following [SemVer](https://semver.org/), and click **Generate release notes**.
+3. **Publish** the release. Packagist picks up the new tag, and the
+   [`update-changelog.yml`](.github/workflows/update-changelog.yml) workflow writes
+   the release notes into `CHANGELOG.md` and commits them back to `master`.
+
+The `Unreleased` section in the changelog is just an anchor — release notes flow
+from the published GitHub release, so there is no changelog to edit by hand.
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Laravel's HTTP client under the hood and caches the OAuth2 access token automati
 ## Requirements
 
 - PHP `>=8.4 <9.0`
-- Laravel 12 / 13 (`illuminate/support` `^12.53 || ^13.0`)
+- Laravel 13+ (`illuminate/support` `^13.0`)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Mirrors puntodev/paypal#50.

- Add `.github/release.yml` so GitHub's **Generate release notes** groups PRs by label (security, features, fixes, maintenance/deps, docs).
- Add `.github/workflows/update-changelog.yml`: on a published release, write the notes into `CHANGELOG.md` and commit them back to `master` via the org-level `RELEASE_TOKEN` PAT (master is a protected branch).
- Rewrite `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) format, backfilling the full release history (`v0.0.1` → `v6.0.0`) with an `Unreleased` anchor.
- Document the release flow in the README.

Repo labels (`security`, `fix`, `chore`, `maintenance`, `ignore-for-release`) were created to match `release.yml` categories.

> Stacked on #53 — base is `docs-laravel-13`. Will retarget once the chain merges.

### Requires
- `RELEASE_TOKEN` secret (org-level admin PAT) for the changelog commit to push to protected `master`, with `enforce_admins` disabled on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)